### PR TITLE
`quickbin`, `main`, `bin` and `extraDeps` attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git add lockfile.jdn
 
 ## Usage
 
-Use `mkJanet` to create derivations:
+Use `mkJanet` to create derivations for executables:
 
 ```nix
 {
@@ -23,7 +23,7 @@ Use `mkJanet` to create derivations:
     my-new-program = janet-nix.packages.${system}.mkJanet {
       name = "my-new-program";
       src = ./.;
-      entry = "./init.janet";
+      quickbin = "init.janet";
     };
   });
 }
@@ -36,6 +36,19 @@ nix build .
 nix run .
 ```
 
+### API
+
+`mkJanet` accepts the following parameters. All are optional aside from `name`, `src` and one of either `quickbin`, `main` or `bin`
+
+- `name` output binary
+- `src` source path or repo, passed to `mkDerivation`
+- `version` passed to `mkDerivation`
+- `buildInputs` additional nix packages
+- `extraDeps` additional Janet sources, see [Tips](#tips)
+- `quickbin` an entry point for `jpm quickbin`
+- `main` specify Janet code to use as the entry point to `jpm quickbin`
+- `bin` specify a binary from `$JANET_TREE/bin` to use as result
+
 ## Templates
 
 Create a minimal Janet project with dev shell and build derivation:
@@ -47,11 +60,32 @@ git init
 git add .
 ```
 
-Alternatively, use the `full` template to include other development tools (only [jfmt](https://github.com/andrewchambers/jfmt) as of now): 
+Alternatively, use the `full` template to include other development tools ([jfmt](https://github.com/andrewchambers/jfmt) and [judge](https://github.com/ianthehenry/judge) as of now): 
 
 ```bash
 nix flake new --template github:turnerdev/janet-nix#full ./my-new-project
 ```
+
+## Tips
+
+**Missing `lockfile.jdn`**
+
+When wrapping third-party repos, you may find that `lockfile.jdn` is missing. To work around this, first check-out the repo in question to a temporary directory, build the lock file as normal and then run:
+
+```bash
+nix run github:turnerdev/janet-nix
+```
+
+To generate a list of nix sources from the lockfile. You can pass this list to `mkJanet` with the `extraDeps` attribute.
+
+# Changelog
+
+## v0.1.0
+- **Breaking change:** Renamed `entry` to `quickbin`
+- Added alternative entry points
+  - `main` to provide Janet code to act as the entry to `jpm quickbin`
+  - `bin` to specify a binary from `$JANET_TREE/bin` to use as result
+- `extraDeps` to pass dependencies directly to `mkJanet`, useful for building third-party repos without a `lockfile.jdn`
 
 # License
 MIT

--- a/main.janet
+++ b/main.janet
@@ -30,12 +30,14 @@
   "Load packages from a lockfile."
   [&opt filename]
   (default filename "lockfile.jdn")
-  (def lockarray (parse (slurp filename)))
-  (do
-    (print "[")
-    (each bundle lockarray
-      (print (nix-source (resolve-bundle bundle))))
-    (print "]")))
+  (if (os/stat filename)
+    (do
+      (def lockarray (parse (slurp filename)))
+      (print "[")
+      (each bundle lockarray
+	(print (nix-source (resolve-bundle bundle))))
+      (print "]"))
+    (file/write stderr "No lockfile.jdn found")))
 
 (defn main
   [& args]

--- a/project.janet
+++ b/project.janet
@@ -1,7 +1,7 @@
 (declare-project
   :name "janet-nix"
   :description ```nix helpers for janet```
-  :version "0.0.1")
+  :version "0.1.0")
 
 (declare-source
   :source ["main.janet"])

--- a/templates/default/flake.nix
+++ b/templates/default/flake.nix
@@ -36,7 +36,7 @@
           name = "my-new-program";
           version = "0.0.1";
           src = ./.;
-          entry = ./init.janet;
+          quickbin = ./init.janet;
         };
       });
 

--- a/templates/full/flake.nix
+++ b/templates/full/flake.nix
@@ -36,7 +36,7 @@
           name = "my-new-program";
           version = "0.0.1";
           src = ./.;
-          entry = ./init.janet;
+          quickbin = ./init.janet;
         };
         jfmt = janet-nix.packages.${system}.mkJanet {
           name = "jfmt";
@@ -44,7 +44,7 @@
             url = "https://github.com/andrewchambers/jfmt.git";
             rev = "b27dff6bb32b89b20462eec33f50c1583c301b0a";
           };
-          entry = "./jfmt.janet";
+          quickbin = "./jfmt.janet";
         };
       });
 
@@ -67,6 +67,13 @@
             export PATH="$PATH:$JANET_TREE/bin"
             mkdir -p "$JANET_TREE"
             mkdir -p "$JANET_BUILDPATH"
+
+            # install judge as a local script
+            if ! command -v <the_command> &> /dev/null
+            then
+                jpm install "https://github.com/ianthehenry/judge.git"
+                exit
+            fi
           '';
         });
     };


### PR DESCRIPTION
- **Breaking change:** Renamed `entry` to `quickbin`
- Added alternative entry points
  - `main` to provide Janet code to act as the entry to `jpm quickbin`
  - `bin` to specify a binary from `$JANET_TREE/bin` to use as result
- `extraDeps` to pass dependencies directly to `mkJanet`, useful for building third-party repos without a `lockfile.jdn`