### PR TITLE
add aarch64-darwin support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   outputs = { self, nixpkgs }:
     let
-      supportedSystems = [ "x86_64-linux" "x86_64-darwin" ];
+      supportedSystems = [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = f:
         nixpkgs.lib.genAttrs supportedSystems (system: f system);
       nixpkgsFor = forAllSystems (system:
@@ -149,7 +149,7 @@
       devShell = forAllSystems (system:
         with nixpkgsFor.${system};
         mkShell {
-          packages = [ janet jpm cntr ];
+          packages = [ janet jpm ];
           buildInputs = [ janet ];
           shellHook = ''
             # localize jpm dependency paths


### PR DESCRIPTION
[cntr](https://github.com/Mic92/cntr) doesn't have support for aarch64-darwin.

I could probably add it conditionally depending on the system if that's desired? I don't usually use nix develop.