### PR TITLE
Fix basic support for declare-binscript

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Use `mkJanet` to create derivations for executables:
 ```nix
 {
   packages = forAllSystems (system: {
-    my-new-program = janet-nix.packages.${system}.mkJanet {
+    my-new-program = janet-nix.legacyPackages.${system}.mkJanet {
       name = "my-new-program";
       src = ./.;
       quickbin = "init.janet";
@@ -79,6 +79,9 @@ nix run github:turnerdev/janet-nix
 To generate a list of nix sources from the lockfile. You can pass this list to `mkJanet` with the `extraDeps` attribute.
 
 # Changelog
+
+## v0.2.0
+- **Breaking change:** Moved `mkJanet` from packages to `legacyPackages`
 
 ## v0.1.0
 - **Breaking change:** Renamed `entry` to `quickbin`

--- a/flake.nix
+++ b/flake.nix
@@ -108,14 +108,12 @@
 
               # if we have quickbin output, use that as the result
               if [ -f "quickbin-out" ]; then
-                mv quickbin-out $out/bin/$name
+                install -m 755 quickbin-out $out/bin/$name
 
               # else if a binary is explicitly passed to mkJanet, use that
               elif [ -n "$bin" ]; then
-                mv "$JANET_TREE/bin/$bin" $out/bin/$name
+                install -m 755 "$JANET_TREE/bin/$bin" $out/bin/$name
               fi
-
-              chmod +x $out/bin/$name
             '';
           };
       };
@@ -131,9 +129,14 @@
         };
       };
 
+      checks = forAllSystems (system: import ./nix/tests.nix nixpkgsFor.${system});
+
       packages = forAllSystems (system: {
         janet-nix = nixpkgsFor.${system}.janet-nix;
-        mkJanet = nixpkgsFor.${system}.mkJanet;
+      });
+
+      legacyPackages = forAllSystems (system: {
+        inherit (nixpkgsFor.${system}) mkJanet;
       });
 
       defaultPackage =

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,0 +1,29 @@
+pkgs:
+{
+  binscript-bin =
+    let
+      src = pkgs.symlinkJoin {
+        name = "src";
+        paths = [
+          (pkgs.writeTextDir "project.janet" ''
+            (declare-project :name "myproj")
+            (declare-binscript :main "src/test")
+          '')
+          (pkgs.writeTextDir "src/test" ''
+            #!/usr/bin/env janet
+            (defn main [& args] (print "binscript-bin"))
+          '')
+        ];
+      };
+      pkg = pkgs.mkJanet {
+        inherit src;
+        name = "test";
+        bin = "test";
+      };
+    in
+    pkgs.runCommand "binscript-bin" { } ''
+      output=$(${pkg}/bin/test)
+      [ "$output" = "binscript-bin" ] || (echo "Unexpected output: $output"; exit 1)
+      touch $out
+    '';
+}

--- a/project.janet
+++ b/project.janet
@@ -1,7 +1,7 @@
 (declare-project
   :name "janet-nix"
   :description ```nix helpers for janet```
-  :version "0.1.0")
+  :version "0.2.0")
 
 (declare-source
   :source ["main.janet"])

--- a/templates/full/flake.nix
+++ b/templates/full/flake.nix
@@ -17,13 +17,13 @@
       nixpkgsFor = forAllSystems (system: import nixpkgs { inherit system; });
     in {
       packages = forAllSystems (system: {
-        my-new-program = janet-nix.packages.${system}.mkJanet {
+        my-new-program = janet-nix.legacyPackages.${system}.mkJanet {
           name = "my-new-program";
           version = "0.0.1";
           src = ./.;
           quickbin = ./init.janet;
         };
-        jfmt = janet-nix.packages.${system}.mkJanet {
+        jfmt = janet-nix.legacyPackages.${system}.mkJanet {
           name = "jfmt";
           src = builtins.fetchGit {
             url = "https://github.com/andrewchambers/jfmt.git";


### PR DESCRIPTION
Breaking: move mkJanet from packages to legacyPackages so that nix flake check passes.

Without this change the added test fails with:
> chmod: changing permissions of '/nix/store/4apkf9lnkrdw5i6f0s1gj6w5i040d3l1-test/bin/test': Operation not permitted