### PR TITLE
Fix declare-binscript with imports

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
           in stdenv.mkDerivation {
             inherit name version src main quickbin bin sources;
 
+            nativeBuildInputs = [ makeWrapper ];
             buildInputs = [ janet jpm ] ++ buildInputs;
 
             buildPhase = ''
@@ -104,6 +105,7 @@
             '';
 
             installPhase = ''
+              cp -rL "$JANET_TREE/." $out
               mkdir -p $out/bin
 
               # if we have quickbin output, use that as the result
@@ -113,6 +115,9 @@
               # else if a binary is explicitly passed to mkJanet, use that
               elif [ -n "$bin" ]; then
                 install -m 755 "$JANET_TREE/bin/$bin" $out/bin/$name
+                if isScript "$JANET_TREE/bin/$bin"; then
+                  wrapProgram $out/bin/$name --set JANET_PATH "$out/lib"
+                fi
               fi
             '';
           };

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -1,5 +1,4 @@
-pkgs:
-{
+pkgs: {
   binscript-bin =
     let
       src = pkgs.symlinkJoin {
@@ -24,6 +23,38 @@ pkgs:
     pkgs.runCommand "binscript-bin" { } ''
       output=$(${pkg}/bin/test)
       [ "$output" = "binscript-bin" ] || (echo "Unexpected output: $output"; exit 1)
+      touch $out
+    '';
+
+  binscript-import =
+    let
+      src = pkgs.symlinkJoin {
+        name = "src";
+        paths = [
+          (pkgs.writeTextDir "project.janet" ''
+            (declare-project :name "myproj")
+            (declare-source :source [ "src/helper.janet" ])
+            (declare-binscript :main "src/test")
+          '')
+          (pkgs.writeTextDir "src/helper.janet" ''
+            (defn greeting [] "binscript-import")
+          '')
+          (pkgs.writeTextDir "src/test" ''
+            #!/usr/bin/env janet
+            (import helper)
+            (defn main [& args] (print (helper/greeting)))
+          '')
+        ];
+      };
+      pkg = pkgs.mkJanet {
+        inherit src;
+        name = "test";
+        bin = "test";
+      };
+    in
+    pkgs.runCommand "binscript-import" { } ''
+      output=$(${pkg}/bin/test)
+      [ "$output" = "binscript-import" ] || (echo "Unexpected output: $output"; exit 1)
       touch $out
     '';
 }


### PR DESCRIPTION
Before this change, the newly added test fails with:

```
       > error: could not find module helper:
       >     /nix/store/45k8cnpf3kqby3yza8b6ffwnx2njgwga-janet-1.28.0/lib/janet/helper.jimage
       >     /nix/store/45k8cnpf3kqby3yza8b6ffwnx2njgwga-janet-1.28.0/lib/janet/helper.janet
       >     /nix/store/45k8cnpf3kqby3yza8b6ffwnx2njgwga-janet-1.28.0/lib/janet/helper/init.janet
       >     /nix/store/45k8cnpf3kqby3yza8b6ffwnx2njgwga-janet-1.28.0/lib/janet/helper.so
       >   in require-1 [boot.janet] on
```