### PR TITLE
Fix declare-binscript with hardcode-syspath

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,14 @@
               elif [ -n "$bin" ]; then
                 install -m 755 "$JANET_TREE/bin/$bin" $out/bin/$name
                 if isScript "$JANET_TREE/bin/$bin"; then
+                  # If :hardcode-syspath is true, jpm hardcodes our local
+                  # syspath which we need to replace with our output path.
+                  #
+                  # Rather than checking to see if that option is set, we use
+                  # --replace which doesn't report an error if no substitution
+                  # is made.
+                  substituteInPlace "$out/bin/$name" \
+                    --replace "$JANET_TREE/lib" "$out/lib"
                   wrapProgram $out/bin/$name --set JANET_PATH "$out/lib"
                 fi
               fi

--- a/nix/tests.nix
+++ b/nix/tests.nix
@@ -57,4 +57,36 @@ pkgs: {
       [ "$output" = "binscript-import" ] || (echo "Unexpected output: $output"; exit 1)
       touch $out
     '';
+
+  binscript-hardcode-syspath =
+    let
+      src = pkgs.symlinkJoin {
+        name = "src";
+        paths = [
+          (pkgs.writeTextDir "project.janet" ''
+            (declare-project :name "myproj")
+            (declare-source :source [ "src/helper.janet" ])
+            (declare-binscript :main "src/test" :hardcode-syspath true)
+          '')
+          (pkgs.writeTextDir "src/helper.janet" ''
+            (defn greeting [] "binscript-hardcode-syspath")
+          '')
+          (pkgs.writeTextDir "src/test" ''
+            #!/usr/bin/env janet
+            (import helper)
+            (print (helper/greeting))
+          '')
+        ];
+      };
+      pkg = pkgs.mkJanet {
+        inherit src;
+        name = "binscript-hardcode-syspath";
+        bin = "test";
+      };
+    in
+    pkgs.runCommand "binscript-hardcode-syspath" { } ''
+      output=$(${pkg}/bin/binscript-hardcode-syspath)
+      [ "$output" = "binscript-hardcode-syspath" ] || (echo "Unexpected output: $output"; exit 1)
+      touch $out
+    '';
 }


### PR DESCRIPTION
Before this change, the newly added test fails with:

```
> error: could not find module helper:
>     /build/src/.jpm/jpm_tree/lib/helper.jimage
>     /build/src/.jpm/jpm_tree/lib/helper.janet
>     /build/src/.jpm/jpm_tree/lib/helper/init.janet
>     /build/src/.jpm/jpm_tree/lib/helper.so
>   in require-1 [boot.janet] on line 2921, column 20
>   in import* [boot.janet] on line 2960, column 15
>   in _thunk [/nix/store/gkx7hakl2i6cm6nv06a5inxibih3fan3-test/bin/.test-wrapped] (tailcall) on line 3, column 1
```